### PR TITLE
corrected handling of 2 error cases

### DIFF
--- a/lib/Service/NetworkService.php
+++ b/lib/Service/NetworkService.php
@@ -154,6 +154,9 @@ class NetworkService {
 			$method,
 			returnRaw: true,
 		);
+		if (is_array($response)) {
+			return $response;
+		}
 		$body = $response->getBody();
 		$respCode = $response->getStatusCode();
 		$headers = $response->getHeaders();
@@ -222,7 +225,7 @@ class NetworkService {
 			$this->logger->error(
 				'Token is not valid anymore. Impossible to refresh it. '
 				. $result['error'] . ' '
-				. $result['error_description'] ?? '[no error description]',
+				. ($result['error_description'] ?? '[no error description]'),
 				['app' => Application::APP_ID]
 			);
 			return false;


### PR DESCRIPTION
1. `request_integration` can return error, check for that was missing.
  Fixes: `Error: Call to a member function getBody() on array` error on nextcloud.log
2. By adding parentheses around $result['error_description'] ?? '[no error description]', we ensure that the null coalescing operator correctly provides a fallback string when error_description is not available in the $result array.
  Fixes: `Undefined array key "error_description" at /var/www/html/apps-extra/integration_jira/lib/Service/NetworkService.php#225`