### PR TITLE
fix: throw UnknownNotificationException for unknown notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.4.2
+
+### Fixed
+
+- Stop spamming the log with `\InvalidArgumentException` deprecation warnings from the notifier; throw `OCP\Notification\UnknownNotificationException` instead for unknown notifications.
+
 ## 1.4.1 - 2025-11-10
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<description><![CDATA[Jira integration provides a dashboard widget displaying your important notifications,
 a unified search provider to search for issues
 and notifications about recent activity related to your assigned issues.]]></description>
-	<version>1.4.1</version>
+	<version>1.4.2</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Jira</namespace>

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -7,7 +7,6 @@
 
 namespace OCA\Jira\Notification;
 
-use InvalidArgumentException;
 use OCA\Jira\AppInfo\Application;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -15,6 +14,7 @@ use OCP\L10N\IFactory;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 
@@ -65,13 +65,13 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification was not prepared by a notifier
 	 * @since 9.0.0
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'integration_jira') {
 			// Not my app => throw
-			throw new InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		$l = $this->factory->get('integration_jira', $languageCode);
@@ -95,7 +95,7 @@ class Notifier implements INotifier {
 
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 }


### PR DESCRIPTION
Same fix as nextcloud/integration_github#202 — throw `OCP\Notification\UnknownNotificationException` instead of `\InvalidArgumentException` for unknown notifications.