### PR TITLE
fix: bump PHP to 8.2+ and NC range to 33-35, sync workflows

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -13,7 +13,7 @@ on:
     types: [published]
 
 env:
-  PHP_VERSION: 8.1
+  PHP_VERSION: 8.2
 
 jobs:
   build_and_publish:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.2', '8.3' ]
 
     name: php-lint
 

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -18,6 +18,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+    outputs:
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+
   changes:
     runs-on: ubuntu-latest-low
     permissions:
@@ -48,16 +63,19 @@ jobs:
   phpunit-sqlite:
     runs-on: ubuntu-latest
 
-    needs: changes
+    needs: [changes, matrix]
     if: needs.changes.outputs.src != 'false'
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3']
-        server-versions: ['stable31', 'stable32', 'master']
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+
+    name: SQLite PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
     steps:
       - name: Set app env
+        if: ${{ env.APP_NAME == '' }}
         run: |
           # Split and keep last
           echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
@@ -84,6 +102,8 @@ jobs:
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development
+          # Temporary workaround for missing pcntl_* in PHP 8.3
+          ini-values: disable_functions=
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -97,7 +117,9 @@ jobs:
         # Only run if phpunit config file exists
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
-        run: composer i
+        run: |
+          composer remove nextcloud/ocp --dev --no-scripts
+          composer i
 
       - name: Set up Nextcloud
         env:
@@ -120,34 +142,16 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}
         run: composer run test:unit
 
-      - name: Check PHPUnit integration script is defined
-        id: check_integration
-        continue-on-error: true
-        working-directory: apps/${{ env.APP_NAME }}
-        run: |
-          composer run --list | grep '^  test:integration ' | wc -l | grep 1
-
-      - name: Run Nextcloud
-        # Only run if phpunit integration config file exists
-        if: steps.check_integration.outcome == 'success'
-        run: php -S localhost:8080 &
-
-      - name: PHPUnit integration
-        # Only run if phpunit integration config file exists
-        if: steps.check_integration.outcome == 'success'
-        working-directory: apps/${{ env.APP_NAME }}
-        run: composer run test:integration
-
       - name: Print logs
         if: always()
         run: |
           cat data/nextcloud.log
 
       - name: Skipped
-        # Fail the action when neither unit nor integration tests ran
-        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        # Fail the action when no unit tests ran
+        if: steps.check_phpunit.outcome == 'failure'
         run: |
-          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          echo 'No PHPUnit tests are specified in composer.json scripts'
           exit 1
 
   summary:

--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -18,27 +18,42 @@ permissions:
   contents: read
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+    outputs:
+      ocp-matrix: ${{ steps.versions.outputs.ocp-matrix }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+
+      - name: Check enforcement of minimum PHP version ${{ steps.versions.outputs.php-min }} in psalm.xml
+        run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml
+
   static-analysis:
     runs-on: ubuntu-latest
+    needs: matrix
+    strategy:
+      # do not stop on another job's failure
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix.outputs.ocp-matrix) }}
 
-    name: static-psalm-analysis
+    name: static-psalm-analysis ${{ matrix.ocp-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Get php version
-        id: versions
-        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2.3.1.3.2
-
-      - name: Check enforcement of minimum PHP version ${{ steps.versions.outputs.php-min }} in psalm.xml
-        run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml
-
-      - name: Set up php${{ steps.versions.outputs.php-available }}
+      - name: Set up php${{ matrix.php-min }}
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
         with:
-          php-version: ${{ steps.versions.outputs.php-available }}
+          php-version: ${{ matrix.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development
@@ -52,8 +67,23 @@ jobs:
           composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
-      - name: Install nextcloud/ocp
-        run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
+      - name: Check for vulnerable PHP dependencies
+        run: composer require --dev roave/security-advisories:dev-latest
+
+      - name: Install dependencies # zizmor: ignore[template-injection]
+        run: composer require --dev 'nextcloud/ocp:${{ matrix.ocp-version }}' --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github
+
+  summary:
+    runs-on: ubuntu-latest-low
+    needs: static-analysis
+
+    if: always()
+
+    name: static-psalm-analysis-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.static-analysis.result != 'success' }}; then exit 1; fi

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,8 +23,8 @@ and notifications about recent activity related to your assigned issues.]]></des
 	<bugs>https://github.com/nextcloud/integration_jira/issues</bugs>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/integration_jira/main/img/screenshot1.jpg</screenshot>
 	<dependencies>
-		<php min-version="8.1"/>
-		<nextcloud min-version="30" max-version="33"/>
+		<php min-version="8.2"/>
+		<nextcloud min-version="33" max-version="35"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Jira\BackgroundJob\CheckOpenTickets</job>

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"psalm/phar": "6.7.x"
 	},
 	"require": {
-		"php": ">=8.1.0"
+		"php": ">=8.2.0"
 	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",
@@ -28,7 +28,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.1.0"
+			"php": "8.2.0"
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0241084ec3dfe8474303247215c1292",
+    "content-hash": "3108b517c156f755f638f643cdcc6991",
     "packages": [],
     "packages-dev": [
         {
@@ -1056,6 +1056,111 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2119,11 +2224,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1.0"
+        "php": ">=8.2.0"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.0"
+        "php": "8.2.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,7 +10,7 @@
 	findUnusedCode="false"
 	resolveFromConfigFile="true"
 	ensureOverrideAttribute="false"
-	phpVersion="8.1"
+	phpVersion="8.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="https://getpsalm.org/schema/config"
 	xsi:schemaLocation="https://getpsalm.org/schema/config vendor-bin/psalm/vendor/vimeo/psalm/config.xsd"


### PR DESCRIPTION
Same kind of fix as nextcloud/integration_github#195. Syncs `psalm.yml` → `psalm-matrix.yml` and `phpunit-sqlite.yml` to the current Nextcloud .github template (uses `nextcloud-version-matrix` action for dynamic NC/PHP matrix). Bumps min PHP to 8.2 and supported Nextcloud range to 33-35 to match what the code uses (`OCP\Search\IExternalProvider` is `@since 32`; PHP 8.2 follows from NC 33's own min PHP).