### PR TITLE
fix: avoid vsprintf ValueError in non-English notification locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Stop spamming the log with `\InvalidArgumentException` deprecation warnings from the notifier; throw `OCP\Notification\UnknownNotificationException` instead for unknown notifications.
+- Fix `ValueError` from `vsprintf()` that broke notifications for non-English users.
 
 ## 1.4.1 - 2025-11-10
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -80,7 +80,7 @@ class Notifier implements INotifier {
 			case 'new_open_tickets':
 				$p = $notification->getSubjectParameters();
 				$nbOpen = (int)($p['nbOpen'] ?? 0);
-				$content = $l->n('You have %s open issue with recent activity in Jira.', 'You have %s open issues with recent activity in Jira.', $nbOpen, [$nbOpen]);
+				$content = $l->n('You have %n open issue with recent activity in Jira.', 'You have %n open issues with recent activity in Jira.', $nbOpen);
 
 				//$theme = $this->config->getUserValue($userId, 'accessibility', 'theme', '');
 				//$iconUrl = ($theme === 'dark')


### PR DESCRIPTION
In `Notifier::prepare()` for `new_open_tickets`, the plural message used `%s` as the counter placeholder. With `%s`, Nextcloud's L10N pipeline never sets `%count%` for Symfony's `IdentityTranslator`, so the imploded `"singular|plural"` translation is returned verbatim and `vsprintf` then trips on the extra `%s` — throwing `ValueError` for every non-English user and breaking the notifications API and mail cron until the rows are deleted from the DB.

Switching the counter to `%n` (the Nextcloud convention) lets the L10N layer pass `%count%` and pick the correct plural form before substitution.

Same bug pattern and fix as nextcloud/integration_github#197 / nextcloud/integration_github#203.