### PR TITLE
fix: migrate Jira Cloud search to /rest/api/3/search/jql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Stop spamming the log with `\InvalidArgumentException` deprecation warnings from the notifier; throw `OCP\Notification\UnknownNotificationException` instead for unknown notifications.
 - Fix `ValueError` from `vsprintf()` that broke notifications for non-English users.
+- Migrate Jira Cloud search and notification calls to `/rest/api/3/search/jql`; the legacy `/rest/api/2/search` endpoint was removed by Atlassian (CHANGE-2046) and Cloud users were getting `410 Gone`. Self-hosted Jira (Server / Data Center) is unaffected and keeps the v2 endpoint (#122).
 
 ## 1.4.1 - 2025-11-10
 

--- a/lib/Service/JiraAPIService.php
+++ b/lib/Service/JiraAPIService.php
@@ -169,13 +169,17 @@ class JiraAPIService {
 				}
 			}
 		} else {
-			// Jira cloud
+			// Jira cloud — /rest/api/2/search was removed (CHANGE-2046),
+			// must use the new /rest/api/3/search/jql endpoint which requires
+			// an explicit JQL and an explicit fields list.
+			$endPoint = 'rest/api/3/search/jql';
+			$params = ['jql' => 'assignee = currentUser()', 'fields' => '*all'];
 			$resources = $this->getJiraResources($userId);
 
 			foreach ($resources as $resource) {
 				$cloudId = $resource['id'];
 				$jiraUrl = $resource['url'];
-				$issuesResult = $this->networkService->oauthRequest($userId, 'ex/jira/' . $cloudId . '/' . $endPoint);
+				$issuesResult = $this->networkService->oauthRequest($userId, 'ex/jira/' . $cloudId . '/' . $endPoint, $params);
 				if (!isset($issuesResult['error']) && isset($issuesResult['issues'])) {
 					foreach ($issuesResult['issues'] as $k => $issue) {
 						$issuesResult['issues'][$k]['jiraUrl'] = $jiraUrl;
@@ -324,7 +328,11 @@ class JiraAPIService {
 				$myIssues[] = $issuesResult['issues'][$k];
 			}
 		} else {
-			// Jira cloud
+			// Jira cloud — /rest/api/2/search was removed (CHANGE-2046),
+			// must use the new /rest/api/3/search/jql endpoint which requires
+			// an explicit fields list.
+			$endPoint = 'rest/api/3/search/jql';
+			$params['fields'] = '*all';
 			$resources = $this->getJiraResources($userId);
 
 			foreach ($resources as $resource) {

--- a/tests/unit/Service/JiraAPIServiceTest.php
+++ b/tests/unit/Service/JiraAPIServiceTest.php
@@ -63,7 +63,8 @@ class JiraAPIServiceTest extends TestCase {
 		$this->networkService->method('oauthRequest')->willReturnCallback(function (
 			string $userId, string $endPoint, array $params = [], string $method = 'GET',
 		) {
-			if (str_contains($endPoint, 'rest/api/2/search')) {
+			if (str_contains($endPoint, 'rest/api/3/search/jql')) {
+				$this->assertSame('*all', $params['fields'] ?? null);
 				return json_decode(file_get_contents('tests/data/search.json'), true);
 			}
 			return 'dummy';


### PR DESCRIPTION
Fixes #122.

Atlassian removed the legacy `/rest/api/{2,3}/search` endpoint in late 2025 ([CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)) - Jira Cloud users have been getting `410 Gone` on every notification cron and unified-search call ever since.
Switch the two Cloud code paths in `JiraAPIService` to the replacement `/rest/api/3/search/jql` endpoint:

- **`search()`** - endpoint swap, plus `fields=*all` added to the existing JQL/params. The new endpoint returns only the issue id by default; `*all` preserves every `issue.fields.*` dereference the backend and frontend already do without auditing them
- **`getNotifications()`** - same endpoint swap. The new endpoint returns `400 Bad Request` on an empty JQL, so the call now passes `jql='assignee = currentUser()'` explicitly. The result set is unchanged for the cron's purpose (it already PHP-filters to assignee-matches-me, kept as a redundant safety net) and we transfer dramatically less data

**Self-hosted Jira keeps using `/rest/api/2/search` - the `basicRequest()` branch in both methods is untouched.
